### PR TITLE
Fix downstream dependencies having to include boost thread

### DIFF
--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -120,4 +120,6 @@ if(BUILD_TESTING)
   )
 endif()
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS socketcan_interface-extras.cmake
+)

--- a/socketcan_interface/socketcan_interface-extras.cmake
+++ b/socketcan_interface/socketcan_interface-extras.cmake
@@ -1,0 +1,6 @@
+find_package(Boost REQUIRED
+  COMPONENTS
+    chrono
+    system
+    thread
+)


### PR DESCRIPTION
Hey,

This is the same fix as https://github.com/ros-industrial/socketcan_interface/pull/1, but I've retargeted it to your branch. I've managed to get `socketcan_interface` working with my hardware. Thanks!

> Downstream dependencies don't know that this package depends on several
> boost components. Linking to socketcan_interface without specifing these
> components will result in a linking error. This package should correctly
> export its linking flags.
> 
> I've followed the answer from the following post to fix this:
> https://answers.ros.org/question/331089/ament_export_dependenciesboost-not-working/?answer=332460#post-id-332460