### PR TITLE
Fix plugin.xml installation path

### DIFF
--- a/socketcan_interface/CMakeLists.txt
+++ b/socketcan_interface/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(${PROJECT_NAME}_plugin
 )
 
 class_loader_hide_library_symbols(${PROJECT_NAME}_plugin)
-install(FILES socketcan_interface_plugin.xml DESTINATION share/${PROJECT_NAME}/socketcan_interface_plugin.xml)
+install(FILES socketcan_interface_plugin.xml DESTINATION share/${PROJECT_NAME}/)
 ament_index_register_resource(socketcan_interface__pluginlib__plugin CONTENT "share/${PROJECT_NAME}/socketcan_interface_plugin.xml\n")
 
 ament_export_dependencies(


### PR DESCRIPTION
Based on testing with the offical `pluginlib_export_plugin_description_file` macro, it seems that the current way of installing plugin.xml is in the wrong folder. It's one folder too deep. See the difference:

#### Installation with pluginlib:
```
pluginlib_export_plugin_description_file(socketcan_interface socketcan_interface_plugin.xml)

find -name '*plugin.xml'
./install/socketcan_interface/share/socketcan_interface/socketcan_interface_plugin.xml

cat ./install/socketcan_interface/share/ament_index/resource_index/socketcan_interface__pluginlib__plugin/socketcan_interface 
share/socketcan_interface/socketcan_interface_plugin.xml
```
#### Installed by current code:
```
find -name socketcan_interface_plugin.xml
./install/socketcan_interface/share/socketcan_interface/socketcan_interface_plugin.xml
./install/socketcan_interface/share/socketcan_interface/socketcan_interface_plugin.xml/socketcan_interface_plugin.xml

cat ./install/socketcan_interface/share/ament_index/resource_index/socketcan_interface__pluginlib__plugin/socketcan_interface 
share/socketcan_interface/socketcan_interface_plugin.xml
```

#### After this PR
```
find -name socketcan_interface_plugin.xml
./install/socketcan_interface/share/socketcan_interface/socketcan_interface_plugin.xml

cat ./install/socketcan_interface/share/ament_index/resource_index/socketcan_interface__pluginlib__plugin/socketcan_interface 
share/socketcan_interface/socketcan_interface_plugin.xml
```
I still could not verify if the plugin actually loads, but that's for another time.